### PR TITLE
Fix file package issues on OSX and enable large files on 32 bit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,8 @@ ALL_CFLAGS = -std=gnu11 -fexceptions \
   -DPONY_VERSION=\"$(tag)\" -DLLVM_VERSION=\"$(llvm_version)\" \
   -DPONY_COMPILER=\"$(CC)\" -DPONY_ARCH=\"$(arch)\" \
   -DBUILD_COMPILER=\"$(compiler_version)\" \
-  -DPONY_BUILD_CONFIG=\"$(config)\"
+  -DPONY_BUILD_CONFIG=\"$(config)\" \
+  -D_FILE_OFFSET_BITS=64
 ALL_CXXFLAGS = -std=gnu++11 -fno-rtti
 
 # Determine pointer size in bits.

--- a/packages/files/file.pony
+++ b/packages/files/file.pony
@@ -448,7 +448,7 @@ class File
     if _fd != -1 then
       let o: ISize = 0
       let b: I32 = 1
-      let r = @lseek64[I64](_fd, o, b)
+      let r = @lseek[I64](_fd, o, b)
 
       if r < 0 then
         _errno = _get_error()
@@ -609,7 +609,7 @@ class File
     Move the cursor position.
     """
     if _fd != -1 then
-      let r = @lseek[I32](_fd, offset, base)
+      let r = @lseek[I64](_fd, offset, base)
       if r < 0 then
         _errno = _get_error()
       end


### PR DESCRIPTION
Prior to this commit the file package used `lseek64` which doesn't
exist on OSX/bsd. This commit fixes linux to enable the
`_FILE_OFFSET_BITS=64` macro to tell linux to have the standard
posix file related calls behave same as for OSX/bsd and use a
64 bit `off_t` even on 32 bit platforms. This also resulted in
being able to use `lseek` on all platforms with a `I64` return type.