### PR TITLE
Fix 32 bit builds with recent file package changes

### DIFF
--- a/src/libponyrt/platform/threads.c
+++ b/src/libponyrt/platform/threads.c
@@ -185,9 +185,9 @@ bool pony_thread_create(pony_thread_id_t* thread, thread_fn start,
       if(getrlimit(RLIMIT_STACK, &limit) == 0)
       {
         int node = _numa_node_of_cpu(cpu);
-        void* stack = _numa_alloc_onnode(limit.rlim_cur, node);
+        void* stack = _numa_alloc_onnode((size_t)limit.rlim_cur, node);
         if (stack != NULL) {
-          pthread_attr_setstack(&attr, stack, limit.rlim_cur);
+          pthread_attr_setstack(&attr, stack, (size_t)limit.rlim_cur);
         }
       }
     }


### PR DESCRIPTION
Prior to this commit 32 bit builds were broken on linux due to
the size of `rlim_t` being 64 bit instead of 32 bit on 32 bit
platforms. This change casts the relevant `rlim_t` to `size_t`
as required to ensure things compile correctly. There should be
no negative consequences to losing the extra bits becuase stack
sizes (for which we use `rlimit`) should never be larger than a
32 bit size on a 32 bit platform. The cast to `size_t` has no
negative impact on 64 bit platforms where `size_t` and `rlim_t`
are both 64 bits already.